### PR TITLE
c6 container from c7 host

### DIFF
--- a/examples/contrib/bootstrap-CentOS6-from-CentOS7.def
+++ b/examples/contrib/bootstrap-CentOS6-from-CentOS7.def
@@ -1,0 +1,31 @@
+#!/bin/bash
+# 
+# Tru Huynh <tru@pasteur.fr>
+
+# bootstrap a minimal CentOS-6 singularity container from a CentOS-7 host
+# workaround the rpmdb/db4 variations
+# http://singularity.lbl.gov/building-centos-image
+
+BootStrap: yum
+OSVersion: 6
+MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+UpdateURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/updates/$basearch/
+
+#MirrorURL: http://ftp.pasteur.fr/mirrors/CentOS/%{OSVERSION}/os/$basearch/
+#UpdateURL: http://ftp.pasteur.fr/mirrors/CentOS/%{OSVERSION}/updates/$basearch/
+
+#MirrorURL: file:///var/ftp/pub/centos//%{OSVERSION}/os/$basearch/
+#UpdateURL: file:///var/ftp/pub/centos//%{OSVERSION}/updates/$basearch/
+Include: yum
+
+%runscript
+echo "This is what happens when you run the container..."
+
+%post
+echo "Hello from inside the container"
+# Q&D fix bootstrap for a CentOS-6 container, hosted on a CentOS-7 host
+(cd /var/lib/rpm && /bin/rm -f __db.*)
+rpm --rebuilddb
+# installing something to make sure that rpm/yum works fine
+yum -y install findutils
+


### PR DESCRIPTION
alternative version (docker being the other one but depens on the availability of the docker hub/network) of generating a CentOS-6 container from a CentOS-7 host. 

Changes proposed in this pull request

 -
 -
 -

@singularityware-admin
